### PR TITLE
Remove unneeded purge key

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,8 @@
 module.exports = {
-  purge: {
     content: [
       './pages/**/*.{js,ts,jsx,tsx}',
       './components/**/*.{js,ts,jsx,tsx}'
     ],
-    layers: ['utilities', 'components'],
-  },
   darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {


### PR DESCRIPTION
Purge has been renamed to content in Tailwind CSS version 3

See https://tailwindcss.com/docs/upgrade-guide#configure-content-sources for details